### PR TITLE
EMM GitHub Updates

### DIFF
--- a/products/github/event_examples/audit/activity_audit_create_resource_pull_request_review_comment.json
+++ b/products/github/event_examples/audit/activity_audit_create_resource_pull_request_review_comment.json
@@ -4,6 +4,7 @@
   "action": "pull_request_review_comment.create",
   "actor": "john.doe",
   "actor_id": 12345678,
+  "actor_ip": "198.51.100.1",
   "business": "acme",
   "business_id": 1122,
   "created_at": 1686079082576,

--- a/products/github/event_examples/audit/activity_audit_create_resource_pull_request_review_comment.json
+++ b/products/github/event_examples/audit/activity_audit_create_resource_pull_request_review_comment.json
@@ -5,6 +5,9 @@
   "actor": "john.doe",
   "actor_id": 12345678,
   "actor_ip": "198.51.100.1",
+  "actor_location": {
+    "country_code": "US"
+  },
   "business": "acme",
   "business_id": 1122,
   "created_at": 1686079082576,

--- a/products/github/event_examples/audit/activity_audit_create_resource_workflow.json
+++ b/products/github/event_examples/audit/activity_audit_create_resource_workflow.json
@@ -5,6 +5,9 @@
   "actor": "john.doe",
   "actor_id": 12345678,
   "actor_ip": "198.51.100.1",
+  "actor_location": {
+    "country_code": "US"
+  },
   "business": "acme",
   "business_id": 1122,
   "created_at": 1686078701893,

--- a/products/github/event_examples/audit/activity_audit_create_resource_workflow.json
+++ b/products/github/event_examples/audit/activity_audit_create_resource_workflow.json
@@ -4,6 +4,7 @@
   "action": "workflows.created_workflow_run",
   "actor": "john.doe",
   "actor_id": 12345678,
+  "actor_ip": "198.51.100.1",
   "business": "acme",
   "business_id": 1122,
   "created_at": 1686078701893,

--- a/products/github/event_examples/audit/activity_audit_update_resource_pull_request_review_comment.json
+++ b/products/github/event_examples/audit/activity_audit_update_resource_pull_request_review_comment.json
@@ -4,6 +4,7 @@
   "action": "pull_request_review_comment.update",
   "actor": "john.doe",
   "actor_id": 12345678,
+  "actor_ip": "198.51.100.1",
   "business": "acme",
   "business_id": 1122,
   "created_at": 1686134016077,

--- a/products/github/event_examples/audit/activity_audit_update_resource_pull_request_review_comment.json
+++ b/products/github/event_examples/audit/activity_audit_update_resource_pull_request_review_comment.json
@@ -5,6 +5,9 @@
   "actor": "john.doe",
   "actor_id": 12345678,
   "actor_ip": "198.51.100.1",
+  "actor_location": {
+    "country_code": "US"
+  },
   "business": "acme",
   "business_id": 1122,
   "created_at": 1686134016077,

--- a/products/github/event_examples/audit/authorization_create_group_team.json
+++ b/products/github/event_examples/audit/authorization_create_group_team.json
@@ -4,6 +4,7 @@
   "action": "team.create",
   "actor": "john.doe",
   "actor_id": 12345678,
+  "actor_ip": "198.51.100.1",
   "actor_location": {
     "country_code": "US"
   },

--- a/products/github/event_examples/audit/authorization_delete_group_team.json
+++ b/products/github/event_examples/audit/authorization_delete_group_team.json
@@ -1,0 +1,23 @@
+{
+    "@timestamp": 1714145080936,
+    "_document_id": "alg4QbCba1UhZA2VFJSTxQ",
+    "action": "team.destroy",
+    "actor": "john.doe",
+    "actor_id": 12345678,
+    "actor_ip": "198.51.100.1",
+    "actor_is_bot": false,
+    "actor_location":
+    {
+        "country_code": "US"
+    },
+    "business": "acme-inc",
+    "business_id": 1234000,
+    "created_at": 1714145080936,
+    "external_identity_nameid": "john@example.com",
+    "external_identity_username": null,
+    "operation_type": "remove",
+    "org": "acme-inc",
+    "org_id": 1234000,
+    "team": "acme-inc/approvers",
+    "user_agent": "Mozilla/5.0 (Macintosh Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+}

--- a/products/github/event_examples/audit/system_audit_create_integration.json
+++ b/products/github/event_examples/audit/system_audit_create_integration.json
@@ -5,6 +5,9 @@
   "actor": "john.doe",
   "actor_id": 12345678,
   "actor_ip": "198.51.100.1",
+  "actor_location": {
+    "country_code": "US"
+  },
   "business": "acme",
   "business_id": 1122,
   "created_at": 1686093901098,

--- a/products/github/event_examples/audit/system_audit_create_integration.json
+++ b/products/github/event_examples/audit/system_audit_create_integration.json
@@ -4,6 +4,7 @@
   "action": "integration.create",
   "actor": "john.doe",
   "actor_id": 12345678,
+  "actor_ip": "198.51.100.1",
   "business": "acme",
   "business_id": 1122,
   "created_at": 1686093901098,

--- a/products/github/event_examples/audit/system_audit_create_security_configuration_forking.json
+++ b/products/github/event_examples/audit/system_audit_create_security_configuration_forking.json
@@ -4,6 +4,7 @@
   "action": "private_repository_forking.enable",
   "actor": "john.doe",
   "actor_id": 12345678,
+  "actor_ip": "198.51.100.1",
   "actor_location": {
     "country_code": "US"
   },

--- a/products/github/event_examples/audit/system_audit_delete_integration.json
+++ b/products/github/event_examples/audit/system_audit_delete_integration.json
@@ -2,9 +2,12 @@
   "@timestamp": 1689093550092,
   "_document_id": "IrAm5tty1DHWLJG7uRCusA",
   "action": "integration.destroy",
-  "actor": "bspcgcg",
+  "actor": "john.doe",
   "actor_id": 12345678,
   "actor_ip": "198.51.100.1",
+  "actor_location": {
+    "country_code": "US"
+  },
   "business": "acme",
   "business_id": 120,
   "created_at": 1689093550092,

--- a/products/github/event_examples/audit/system_audit_delete_integration.json
+++ b/products/github/event_examples/audit/system_audit_delete_integration.json
@@ -4,6 +4,7 @@
   "action": "integration.destroy",
   "actor": "bspcgcg",
   "actor_id": 12345678,
+  "actor_ip": "198.51.100.1",
   "business": "acme",
   "business_id": 120,
   "created_at": 1689093550092,

--- a/products/github/event_examples/audit/system_audit_update_security_configuration_hook_config.json
+++ b/products/github/event_examples/audit/system_audit_update_security_configuration_hook_config.json
@@ -5,6 +5,7 @@
   "active": true,
   "actor": "john.doe",
   "actor_id": 12345678,
+  "actor_ip": "198.51.100.1",
   "actor_location": {
     "country_code": "US"
   },

--- a/products/github/event_sources/audit_events.yml
+++ b/products/github/event_sources/audit_events.yml
@@ -45,6 +45,7 @@ mappings:
       A0003: action
       A0005: actor
       A0006: actor_id
+      A0009: actor_ip
       A0010: actor_location.country_code
       A0011: user_agent
       A0021: [org, team]

--- a/products/github/event_sources/audit_events.yml
+++ b/products/github/event_sources/audit_events.yml
@@ -46,7 +46,6 @@ mappings:
       A0003: action
       A0005: actor
       A0006: actor_id
-      A0009: actor_ip
       A0010: actor_location.country_code
       A0011: user_agent
       A0021: [org, team]
@@ -68,6 +67,21 @@ mappings:
     examples:
       - type: success
         location: "./event_examples/audit/authorization_update_group_team.json"
+  - category: C0002
+    event_type: ET0011
+    attributes:
+      A0001: created_at
+      A0002: _document_id
+      A0003: action
+      A0005: actor
+      A0006: actor_id
+      A0009: actor_ip
+      A0010: actor_location.country_code
+      A0011: user_agent
+      A0021: [org, team]
+    examples:
+      - type: success
+        location: "./event_examples/audit/authorization_delete_group_team.json"
   - category: C0002
     event_type: ET0012
     attributes:

--- a/products/github/event_sources/audit_events.yml
+++ b/products/github/event_sources/audit_events.yml
@@ -30,7 +30,6 @@ mappings:
       A0003: action
       A0005: actor
       A0006: actor_id
-      A0009: actor_ip
       A0010: actor_location.country_code
       A0011: user_agent
       A0014: action
@@ -203,6 +202,21 @@ mappings:
     examples:
       - type: success
         location: "./event_examples/audit/system_audit_create_integration.json"
+  - category: C0003
+    event_type: ET0029
+    attributes:
+      A0001: created_at
+      A0002: _document_id
+      A0003: action
+      A0005: actor
+      A0006: actor_id
+      A0009: actor_ip
+      A0010: actor_location.country_code
+      A0011: user_agent
+      A0029: integration
+    examples:
+      - type: success
+        location: "./event_examples/audit/system_audit_delete_integration.json"
   - category: C0004
     event_type: ET0030
     attributes:


### PR DESCRIPTION
+ Add `actor_ip` and `actor_location` to a few event examples where they were missing.
+ Removed `actor_ip` from "Account Login" (ET0001) events, which I believe was an error.
+ Updated the GitHub assessment to include coverage for "Delete Group" (ET0011) and added an example event.
+ Fixed a bug where we had an example event for "Delete Integration" (ET0029) but hadn't added it to the assessment.
